### PR TITLE
Username/Password Validation + Bug fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,14 @@
             <scope>compile</scope>
         </dependency>
 
+        <!-- Password Validation -->
+        <dependency>
+            <groupId>org.passay</groupId>
+            <artifactId>passay</artifactId>
+            <version>1.6.0</version>
+            <scope>compile</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>

--- a/src/main/java/org/eimerarchive/archive/config/WebMvcConfiguration.java
+++ b/src/main/java/org/eimerarchive/archive/config/WebMvcConfiguration.java
@@ -1,6 +1,6 @@
 package org.eimerarchive.archive.config;
 
-import org.eimerarchive.archive.config.resovlers.AccountArgumentResolver;
+import org.eimerarchive.archive.config.resolvers.AccountArgumentResolver;
 import org.eimerarchive.archive.repositories.AccountRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/org/eimerarchive/archive/config/resolvers/AccountArgumentResolver.java
+++ b/src/main/java/org/eimerarchive/archive/config/resolvers/AccountArgumentResolver.java
@@ -1,4 +1,4 @@
-package org.eimerarchive.archive.config.resovlers;
+package org.eimerarchive.archive.config.resolvers;
 
 import org.eimerarchive.archive.model.Account;
 import org.eimerarchive.archive.repositories.AccountRepository;

--- a/src/main/java/org/eimerarchive/archive/controller/InfoController.java
+++ b/src/main/java/org/eimerarchive/archive/controller/InfoController.java
@@ -1,5 +1,6 @@
 package org.eimerarchive.archive.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.eimerarchive.archive.config.exception.RestErrorCode;
 import org.eimerarchive.archive.dtos.in.auth.UserFromTokenRequest;
@@ -27,7 +28,7 @@ public class InfoController {
     private final TokenRepository tokenRepository;
 
     @PostMapping("info")
-    public ResponseEntity<?> getAccountInfoFromToken(@RequestBody UserFromTokenRequest dto) {
+    public ResponseEntity<?> getAccountInfoFromToken(@RequestBody @Valid UserFromTokenRequest dto) {
 
         Optional<Token> optionalToken = tokenRepository.findByToken(UUID.fromString(dto.getToken()));
         if (optionalToken.isEmpty()) return ResponseEntity.badRequest().body(ErrorResponse.create(RestErrorCode.FORBIDDEN.getDescription()));

--- a/src/main/java/org/eimerarchive/archive/dtos/in/auth/SignupRequest.java
+++ b/src/main/java/org/eimerarchive/archive/dtos/in/auth/SignupRequest.java
@@ -2,11 +2,19 @@ package org.eimerarchive.archive.dtos.in.auth;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import org.eimerarchive.archive.validation.ValidPassword;
 
 public class SignupRequest {
     @NotBlank
-    @Size(min = 3, max = 20)
+    @Size(min = 4, max = 20)
+    @Pattern.List({
+            // Ascii Only
+            @Pattern(regexp = "^((?![^\\x00-\\x7F]).)*$"),
+            // We do not want people creating usernames like XxAnalPvP69xX
+            @Pattern(regexp = "^((?!xx).)*$", flags = Pattern.Flag.CASE_INSENSITIVE)
+    })
     private String username;
 
     @NotBlank
@@ -15,7 +23,8 @@ public class SignupRequest {
     private String email;
 
     @NotBlank
-    @Size(min = 6, max = 40)
+    @Size(min = 8, max = 40)
+    @ValidPassword
     private String password;
 
     public String getUsername() {

--- a/src/main/java/org/eimerarchive/archive/dtos/in/auth/UserFromTokenRequest.java
+++ b/src/main/java/org/eimerarchive/archive/dtos/in/auth/UserFromTokenRequest.java
@@ -1,8 +1,10 @@
 package org.eimerarchive.archive.dtos.in.auth;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class UserFromTokenRequest {
+    @NotBlank
     private String token;
 }

--- a/src/main/java/org/eimerarchive/archive/model/Role.java
+++ b/src/main/java/org/eimerarchive/archive/model/Role.java
@@ -1,7 +1,9 @@
 package org.eimerarchive.archive.model;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.eimerarchive.archive.model.enums.ERole;
 
@@ -9,6 +11,8 @@ import org.eimerarchive.archive.model.enums.ERole;
 @Setter
 @Entity
 @Table(name = "roles")
+@NoArgsConstructor
+@AllArgsConstructor
 public class Role {
 
     @Id

--- a/src/main/java/org/eimerarchive/archive/repositories/RoleRepository.java
+++ b/src/main/java/org/eimerarchive/archive/repositories/RoleRepository.java
@@ -10,4 +10,15 @@ import java.util.Optional;
 @Repository
 public interface RoleRepository extends JpaRepository<Role, Long> {
     Optional<Role> findByName(ERole name);
+
+    default Role findRole(ERole name) {
+        Optional<Role> queried = this.findByName(name);
+        if (queried.isEmpty()) {
+            this.saveAndFlush(new Role(null, name));
+
+            return findRole(name);
+        }
+
+        return queried.get();
+    }
 }

--- a/src/main/java/org/eimerarchive/archive/repositories/TokenRepository.java
+++ b/src/main/java/org/eimerarchive/archive/repositories/TokenRepository.java
@@ -10,6 +10,5 @@ import java.util.UUID;
 @Repository
 public interface TokenRepository extends JpaRepository<Token, UUID> {
     Optional<Token> findByToken(UUID token);
-
     boolean existsByToken(UUID token);
 }

--- a/src/main/java/org/eimerarchive/archive/service/AccountService.java
+++ b/src/main/java/org/eimerarchive/archive/service/AccountService.java
@@ -7,6 +7,7 @@ import org.eimerarchive.archive.dtos.in.auth.LoginRequest;
 import org.eimerarchive.archive.dtos.in.auth.SignupRequest;
 import org.eimerarchive.archive.dtos.out.ErrorResponse;
 import org.eimerarchive.archive.model.Account;
+import org.eimerarchive.archive.model.Role;
 import org.eimerarchive.archive.model.Settings;
 import org.eimerarchive.archive.model.Token;
 import org.eimerarchive.archive.model.enums.ERole;
@@ -77,7 +78,7 @@ public class AccountService implements UserDetailsService {
 
         // Create new user's account
         Account account = new Account(signUpRequest.getUsername(), signUpRequest.getEmail(), this.encoder.encode(signUpRequest.getPassword()), null);
-        account.setRoles(new HashSet<>(Collections.singleton(roleRepository.findByName(ERole.ROLE_USER).get())));
+        account.setRoles(new HashSet<>(Collections.singleton(roleRepository.findRole(ERole.ROLE_USER))));
 
         accountRepository.save(account);
 

--- a/src/main/java/org/eimerarchive/archive/validation/PasswordConstraintValidator.java
+++ b/src/main/java/org/eimerarchive/archive/validation/PasswordConstraintValidator.java
@@ -1,0 +1,77 @@
+package org.eimerarchive.archive.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.Cleanup;
+import org.passay.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * A custom jakarta.validation validator for passwords.
+ * Uses the Passay library to make validation easy.
+ *
+ * @author steviebeenz
+ * @see ValidPassword
+ */
+public class PasswordConstraintValidator implements ConstraintValidator<ValidPassword, String> {
+    private PasswordValidator validator;
+    @Override
+    public void initialize(final ValidPassword arg0) {
+        // Load the messages for passay validation
+        // This file is shaded with passay
+        MessageResolver messageResolver;
+        try {
+            Properties props = new Properties();
+            URL propertiesURL = getClass()
+                    .getClassLoader().getResource("passay.properties");
+            final @Cleanup InputStream inputStream = propertiesURL.openStream();
+            props.load(inputStream);
+            messageResolver = new PropertiesMessageResolver(props);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load passay messages", e);
+        }
+
+        // Create the validator object (a spring DI based version of this would be nice)
+        this.validator = new PasswordValidator(messageResolver, List.of(
+                // length must be at least 8 and no more than 32
+                // prevents short passwords and spam
+                new LengthRule(8, 32),
+                /*
+                the below four rules help encourage the use of random passwords.
+                this helps also stop people from using their name but
+                first letter capitalised, some number somewhere and a dot at the end.
+                */
+                // we want to ensure there is an uppercase character
+                new CharacterRule(EnglishCharacterData.UpperCase, 2),
+                // we want people to not go all upper-case
+                new CharacterRule(EnglishCharacterData.LowerCase, 2),
+                // we want people to use numbers, but not just swap one character
+                new CharacterRule(EnglishCharacterData.Digit, 2),
+                // we want people to use special characters, but not just a dot at the end.
+                new CharacterRule(EnglishCharacterData.Special, 2),
+                // stop number spam
+                new IllegalSequenceRule(EnglishSequenceData.Numerical, 4, false),
+                // stop people just using QWERTY or similar
+                new IllegalSequenceRule(EnglishSequenceData.USQwerty, 4, false)
+        ));
+
+    }
+    @Override
+    public boolean isValid(String password, ConstraintValidatorContext context) {
+        RuleResult result = this.validator.validate(new PasswordData(password));
+        if (result.isValid()) {
+            return true;
+        }
+        List<String> messages = this.validator.getMessages(result);
+        String messageTemplate = String.join(",", messages);
+        context.buildConstraintViolationWithTemplate(messageTemplate)
+                .addConstraintViolation()
+                .disableDefaultConstraintViolation();
+        return false;
+    }
+}

--- a/src/main/java/org/eimerarchive/archive/validation/ValidPassword.java
+++ b/src/main/java/org/eimerarchive/archive/validation/ValidPassword.java
@@ -1,0 +1,27 @@
+package org.eimerarchive.archive.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.annotation.RetentionPolicy;
+
+import java.lang.annotation.ElementType;
+
+/**
+ * The annotation for a custom password validator
+ *
+ * @author steviebeenz
+ * @see PasswordConstraintValidator
+ */
+@Constraint(validatedBy = PasswordConstraintValidator.class)
+@Target({ ElementType.TYPE, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidPassword {
+    String message() default "Invalid Password";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}


### PR DESCRIPTION
- Implement Username/Password Validation for SignupRequest (allows ASCII characters only, and prevents XX in usernames to prevent problematic usernames)
- Corrected a package typo (resovlers) to (resolvers)
- Implemented NotBlank validation for UserFromTokenRequest to prevent issues when not logged in.
- Updated the RoleRepository and AccountService to automatically add roles from the ENUM to the database when they do not already exist (this is not done well and may need to be redone)